### PR TITLE
Add woodpecker configs

### DIFF
--- a/.woodpecker/.build-pr.yml
+++ b/.woodpecker/.build-pr.yml
@@ -1,0 +1,9 @@
+pipeline:
+  build-pr:
+    image: plugins/docker
+    settings:
+      repo: "${CI_REPO_OWNER}/${CI_REPO_NAME}"
+      dry_run: true
+when:
+  event:
+    - pull_request

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -1,0 +1,10 @@
+pipeline:
+  push-latest:
+    image: plugins/docker
+    settings:
+      repo: "${CI_REPO_OWNER}/${CI_REPO_NAME}"
+      tags: latest
+    secrets: [ docker_username, docker_password ]
+when:
+  branch: master
+  event: push

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,0 +1,10 @@
+pipeline:
+  release:
+    image: plugins/docker
+    settings:
+      repo: "${CI_REPO_OWNER}/${CI_REPO_NAME}"
+      tags: "${CI_COMMIT_TAG##v}"
+    secrets: [ docker_username, docker_password ]
+when:
+  event: tag
+  tag: v*


### PR DESCRIPTION
It seems that this repository did not have a drone or woodpecker configuration set up yet. This PR adds a woodpecker config for PRs, push to master and docker releases when a tag has been created.