### PR TITLE
GN-4373: prevent `undefined` error in `requiresMelding` by checking if query has any results

### DIFF
--- a/support/queries.js
+++ b/support/queries.js
@@ -305,6 +305,9 @@ async function requiresMelding(resource) {
   `;
   const results = await query(informationQuery);
   const informationObject = parseResult(results)[0];
+  if(!informationObject){
+    return false;
+  }
   console.log(`TESTING IF RESOURCE ${resource} REQUIRES MELDING`);
   //Make sure that if no date was found, the date of this moment is taken (should only be minutes after the real publication)
   informationObject.publicationDate = informationObject.publicationDate || new Date();

--- a/support/queries.js
+++ b/support/queries.js
@@ -306,6 +306,7 @@ async function requiresMelding(resource) {
   const results = await query(informationQuery);
   const informationObject = parseResult(results)[0];
   if(!informationObject){
+    console.error(`Querying information about ${resource} gave no results. This should not happen.`)
     return false;
   }
   console.log(`TESTING IF RESOURCE ${resource} REQUIRES MELDING`);


### PR DESCRIPTION
### Description
This PR ensures that if no results are returned by the resource query in the `requiresMelding` function, `false` is returned. Before, an `undefined` error was thrown and was blocking the mutex, not allowing any other published resources to be handled.

### Linked issues
Solves part of https://binnenland.atlassian.net/browse/GN-4373?atlOrigin=eyJpIjoiNmNmOWVhMjA0MDY5NGQwMmIxMjllMjgzOGYzMGJlMDYiLCJwIjoiaiJ9

### setup:

<details>
<summary>publication override</summary>

```yml
version: "3.4"

services:
  identifier:
    restart: "no"
    networks:
      default:
        aliases:
          - publication_identifier

  published-resource-consumer:
    restart: "no"
    environment:
      NODE_ENV: development
      SERVICE_NAME: 'published-resource-consumer'
      SYNC_BASE_URL: 'http://gn-identifier'
      INGEST_INTERVAL: 5000
    networks:
      - default
      - shared-gn-pub
  publicatie-melding:
    environment:
      NODE_ENV: "development"
    volumes:
      - /home/elena/Projects/lblod/apps/besluit-publicatie-melding-service/:/app/ #replace by local version of this branch

networks:
  shared-gn-pub:
    name: shared-gn-pub
```

disable `command: "/bin/false"`; in publicatie-melding in `docker-compose.dev.yml`

</details>

<details>
<summary>GN override</summary>

```yaml
version: "3.4"
x-logging: &default-logging
  driver: "json-file"
  options:
    max-size: "10m"
    max-file: "3"
services:
  identifier:
    ports:
      - "4302:80"
    environment:
      SESSION_COOKIE_SECURE: "false"
    networks:
      default:
      shared-gn-pub:
        aliases:
          - gn-identifier
    restart: no
networks:
  shared-gn-pub:
    name: shared-gn-pub

```
</details>


### How to test
Quite hard, this issue only occurs when the resource query in  `requiresMelding` produces no results.
