### PR TITLE
GN-4373: update url construction for published resources to reflect gn-publication route changes

### DIFF
--- a/support/pipeline.js
+++ b/support/pipeline.js
@@ -63,10 +63,10 @@ async function createPayloadToSubmit(type, extractedResource, zittingId, bestuur
       because they are not a decison type in themselves so we need to pass the decision contained in them as payload.
     */
     const uittrekselUuid = await getUuid(extractedResource);
-    href = SOURCE_HOST + `/${bestuurseenheidLabel}/${classificatieLabel}/${zittingId}/${RESOURCE_TO_URL_TYPE_MAP[type]}/${uittrekselUuid}`;
+    href = SOURCE_HOST + `/${bestuurseenheidLabel}/${classificatieLabel}/zittingen/${zittingId}/${RESOURCE_TO_URL_TYPE_MAP[type]}/${uittrekselUuid}`;
     extractedResource = await getDecisionFromUittreksel(extractedResource);
   } else {
-    href = SOURCE_HOST + `/${bestuurseenheidLabel}/${classificatieLabel}/${zittingId}/${RESOURCE_TO_URL_TYPE_MAP[type]}`;
+    href = SOURCE_HOST + `/${bestuurseenheidLabel}/${classificatieLabel}/zittingen/${zittingId}/${RESOURCE_TO_URL_TYPE_MAP[type]}`;
   }
 
   return {


### PR DESCRIPTION
### Description
This PR ensures that a correct url is constructed when creating the payload for a published resource as the route structure of GN-publicatie has recently changed.

Instead of `/${bestuurseenheidLabel}/${classificatieLabel}/${zittingId}/${RESOURCE_TO_URL_TYPE_MAP[type]}`, `/${bestuurseenheidLabel}/${classificatieLabel}/zittingen/${zittingId}/${RESOURCE_TO_URL_TYPE_MAP[type]}` is now used.

### Linked issues
Solves part of https://binnenland.atlassian.net/browse/GN-4373?atlOrigin=eyJpIjoiNmNmOWVhMjA0MDY5NGQwMmIxMjllMjgzOGYzMGJlMDYiLCJwIjoiaiJ9

Related commit: https://github.com/lblod/frontend-gelinkt-notuleren-publicatie/commit/a44b76219cdc46f6b919b084c9ce7f5675f03818

### setup:

<details>
<summary>publication override</summary>

```yml
version: "3.4"

services:
  identifier:
    restart: "no"
    networks:
      default:
        aliases:
          - publication_identifier

  published-resource-consumer:
    restart: "no"
    environment:
      NODE_ENV: development
      SERVICE_NAME: 'published-resource-consumer'
      SYNC_BASE_URL: 'http://gn-identifier'
      INGEST_INTERVAL: 5000
    networks:
      - default
      - shared-gn-pub
  publicatie-melding:
    environment:
      NODE_ENV: "development"
    volumes:
      - /home/elena/Projects/lblod/apps/besluit-publicatie-melding-service/:/app/ #replace by local version of this branch

networks:
  shared-gn-pub:
    name: shared-gn-pub
```

disable `command: "/bin/false"`; in publicatie-melding in `docker-compose.dev.yml`

</details>

<details>
<summary>GN override</summary>

```yaml
version: "3.4"
x-logging: &default-logging
  driver: "json-file"
  options:
    max-size: "10m"
    max-file: "3"
services:
  identifier:
    ports:
      - "4302:80"
    environment:
      SESSION_COOKIE_SECURE: "false"
    networks:
      default:
      shared-gn-pub:
        aliases:
          - gn-identifier
    restart: no
networks:
  shared-gn-pub:
    name: shared-gn-pub

```
</details>


### How to test
Publish the decision-list or an extract with a decision with the correct type of the meeting, when viewing the logs of the `melding-service`, the request to the constructed url should now longer fail
