### PR TITLE
Fix error handling in `rescheduleUnproccessedTasks`

### DIFF
--- a/app.js
+++ b/app.js
@@ -151,10 +151,7 @@ async function rescheduleUnproccessedTasks(firstTime){
         await executeSubmitTask(task);
       }
       catch(error){
-        //if rescheduling fails, we consider there is something really broken...
-        console.log(`Fatal error for ${task.subject}`);
-        await updateTask(task.subject, FAILED_STATUS, task.numberOfRetries);
-        await updatePublishedResourceStatus(task.involves, FAILED_SUBMISSION_STATUS);
+        handleTaskError(error, task);
       }
     }
   } catch(error){


### PR DESCRIPTION
The `numberOfRetries` was not incremented when `rescheduleUnproccessedTasks` failed. This caused the task to be endlessly rescheduled for a melding.

The code already had a `handleTaskError` function to properly handle task failures, so the catch block was replaced with a call to this function.