### PR TITLE
Correctly process the already submitted error from the automatic submission service

### DIFF
--- a/.woodpecker/.build-pr.yml
+++ b/.woodpecker/.build-pr.yml
@@ -1,4 +1,4 @@
-pipeline:
+steps:
   build-pr:
     image: plugins/docker
     settings:

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -1,4 +1,4 @@
-pipeline:
+steps:
   push-latest:
     image: plugins/docker
     settings:

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -4,7 +4,10 @@ pipeline:
     settings:
       repo: "${CI_REPO_OWNER}/${CI_REPO_NAME}"
       tags: latest
-    secrets: [ docker_username, docker_password ]
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
   branch: master
   event: push

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,4 +1,4 @@
-pipeline:
+steps:
   release:
     image: plugins/docker
     settings:

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -4,7 +4,10 @@ pipeline:
     settings:
       repo: "${CI_REPO_OWNER}/${CI_REPO_NAME}"
       tags: "${CI_COMMIT_TAG##v}"
-    secrets: [ docker_username, docker_password ]
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
   event: tag
   tag: v*

--- a/app.js
+++ b/app.js
@@ -106,7 +106,7 @@ async function processPublishedResources(publishedResourceUris){
             ALREADY_SUBMITED_SUBMISSION_STATUS
           );
           const responseJson = await response.json();
-          await generateAlreadySubmittedLog(responseJson, task.involves);
+          await generateAlreadySubmittedLog(responseJson, task.involves, task.subject);
         }
         else {
           handleTaskError("error submitting resource ${pr}, status: ${response.statusText}. ${body.text()}", task);

--- a/app.js
+++ b/app.js
@@ -26,6 +26,9 @@ import { executeSubmitTask } from './support/pipeline.js';
 import bodyParser from 'body-parser';
 import { CronJob } from 'cron';
 import { Mutex } from 'async-mutex';
+import {
+	StatusCodes,
+} from 'http-status-codes';
 
 
 const mutex = new Mutex();
@@ -91,7 +94,7 @@ async function processPublishedResources(publishedResourceUris){
         if (response.ok) {
           await updateTask(task.subject, SUCCESS_STATUS, task.numberOfRetries);
           await updatePublishedResourceStatus(task.involves, SUCCESS_SUBMISSION_STATUS);
-        } else if (response.status === 409) {
+        } else if (response.status === StatusCodes.CONFLICT) {
           await updateTask(
             task.subject,
             ALREADY_SUBMITED_STATUS,
@@ -102,7 +105,7 @@ async function processPublishedResources(publishedResourceUris){
             ALREADY_SUBMITED_SUBMISSION_STATUS
           );
           const responseJson = await response.json();
-          await generateAlreadySubmittedLog(responseJson);
+          await generateAlreadySubmittedLog(responseJson, task.involves);
         }
         else {
           handleTaskError("error submitting resource ${pr}, status: ${response.statusText}. ${body.text()}", task);

--- a/app.js
+++ b/app.js
@@ -20,7 +20,8 @@ import {
   updatePublishedResourceStatus,
   getPublishedResourcesFromDelta ,
   getResourcesWithoutTask,
-  refreshReportingData
+  refreshReportingData,
+  generateAlreadySubmittedLog
 } from './support/queries.js';
 import { executeSubmitTask } from './support/pipeline.js';
 import bodyParser from 'body-parser';

--- a/app.js
+++ b/app.js
@@ -8,7 +8,6 @@ import {
   SUCCESS_SUBMISSION_STATUS,
   ALREADY_SUBMITED_STATUS,
   ALREADY_SUBMITED_SUBMISSION_STATUS,
-  updatePublishedResourceStatus
 } from './support/queries.js' ;
 import { waitForDatabase } from './database-utils.js';
 import { 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "async-mutex": "^0.3.1",
     "cron": "^1.3.0",
     "graph-rdfa-processor": "^1.3.0",
+    "http-status-codes": "^2.3.0",
     "jsdom": "^11.6.2",
     "lodash.flatten": "^4.4.0",
     "lodash.uniq": "^4.5.0",

--- a/support/queries.js
+++ b/support/queries.js
@@ -9,9 +9,12 @@ const DEFAULT_GRAPH = (process.env || {}).DEFAULT_GRAPH || 'http://mu.semte.ch/g
 const PENDING_STATUS = "http://lblod.data.gift/besluit-publicatie-melding-statuses/ongoing";
 const FAILED_STATUS = "http://lblod.data.gift/besluit-publicatie-melding-statuses/failure";
 const SUCCESS_STATUS = "http://lblod.data.gift/besluit-publicatie-melding-statuses/success";
+const ALREADY_SUBMITED_STATUS = "http://lblod.data.gift/besluit-publicatie-melding-statuses/already-submitted";
 const PENDING_SUBMISSION_STATUS = "http://lblod.data.gift/publication-submission-statuses/ongoing";
 const FAILED_SUBMISSION_STATUS = "http://lblod.data.gift/publication-submission-statuses/failure";
 const SUCCESS_SUBMISSION_STATUS = "http://lblod.data.gift/publication-submission-statuses/success";
+const ALREADY_SUBMITED_SUBMISSION_STATUS = "http://lblod.data.gift/publication-submission-statuses/already-submitted";
+
 
 const BESLUIT_TYPES_ENDPOINT = (process.env || {}).BESLUIT_TYPES_ENDPOINT || 'https://centrale-vindplaats.lblod.info/sparql';
 const BESTUURSORGANEN_NEED_PUBLISHING = [

--- a/support/queries.js
+++ b/support/queries.js
@@ -538,7 +538,7 @@ async function getResourcesWithoutTask() {
   return parsedResult;
 }
 
-async function generateAlreadySubmittedLog(responseJson, resourceUri) {
+async function generateAlreadySubmittedLog(responseJson, resourceUri, taskUri) {
   const logEntryUuid = uuid();
   const logEntryUri = `http://data.lblod.info/id/log-entries/${logEntryUuid}`;
   const logLevel =
@@ -562,6 +562,7 @@ async function generateAlreadySubmittedLog(responseJson, resourceUri) {
           mu:uuid ${sparqlEscapeString(logEntryUuid)};
           rlog:level ${sparqlEscapeUri(logLevel)};
           rlog:message ${sparqlEscapeString(message)};
+          rlog:resource ${sparqlEscapeUri(taskUri)};
           rlog:date ${sparqlEscapeDateTime(now)};
           dct:created ${sparqlEscapeDateTime(now)};
           dct:source ${sparqlEscapeString(source)}.

--- a/support/queries.js
+++ b/support/queries.js
@@ -538,7 +538,7 @@ async function getResourcesWithoutTask() {
   return parsedResult;
 }
 
-async function generateAlreadySubmittedLog(responseJson) {
+async function generateAlreadySubmittedLog(responseJson, resourceUri) {
   const logEntryUuid = uuid();
   const logEntryUri = `http://data.lblod.info/id/log-entries/${logEntryUuid}`;
   const logLevel =
@@ -548,6 +548,8 @@ async function generateAlreadySubmittedLog(responseJson) {
   let message;
   if (responseJson.errors && responseJson.errors.length) {
     message = responseJson.errors.map((error) => error.title).join("\n ");
+  } else {
+    message = `Error: the resource ${resourceUri} was already submitted at the endpoint`
   }
   
   let queryString = `


### PR DESCRIPTION
When you try to process an already submitted publication you get a 409 error from the automatic submission service, before this service identified that as a normal error an marked the task for a retry, but this shouldn't happen as that error won't stop ocurring for much we retry the task, so I marked it with a new status code and added a rlog to avoid silent fails.
